### PR TITLE
Handle request errors in Shecan check loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -319,6 +319,7 @@ func runDiagnostic() {
 			fmt.Println(colorMap["red"], "[Error] Can't Get Check Shecan Result")
 			fmt.Println(colorMap["red"], err)
 			report.CheckShecanResult[ip] = CheckShecan{Error: fmt.Sprintf("Error: %v", err)}
+			continue
 		}
 		defer response.Body.Close()
 		body, err := io.ReadAll(response.Body)


### PR DESCRIPTION
## Summary
- avoid panic when HTTP request fails during Shecan check

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed8dbf088330a7975af7fb3fe475