### PR TITLE
Add README and run command as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Shecan Diagnostic
+
+This tool gathers network diagnostics related to the [Shecan](https://shecan.ir) DNS service. It checks DNS connectivity, pings Shecan servers, performs lookups and sends a diagnostic report.
+
+## Building
+
+```bash
+# build a binary named `shecan-diagnostic`
+go build -o shecan-diagnostic
+```
+
+## Usage
+
+Run the binary directly to start the diagnostic workflow. You can optionally supply a plan flag (`--plan` or `-p`) with values `Free` or `Pro`.
+
+```bash
+# run with interactive plan selection
+./shecan-diagnostic
+
+# or explicitly set the plan
+./shecan-diagnostic --plan Free
+```
+
+The command `run` is the default action and executes automatically when no arguments are provided.

--- a/root.go
+++ b/root.go
@@ -10,6 +10,9 @@ var PlanFlag string
 var rootCmd = &cobra.Command{
 	Use:   "diagnostic",
 	Short: "Run DNS diagnostic tool",
+	Run: func(cmd *cobra.Command, args []string) {
+		runDiagnostic()
+	},
 }
 
 func Execute() error {


### PR DESCRIPTION
## Summary
- document how to build and run the diagnostic tool
- default to the `run` command when executed without subcommands

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846ef7398148330889e915aad23a090